### PR TITLE
Allow init_app to be called after package load.

### DIFF
--- a/flask_babelex/__init__.py
+++ b/flask_babelex/__init__.py
@@ -73,6 +73,9 @@ class Babel(object):
         else:
             self._default_domain = default_domain
 
+        self.locale_selector_func = None
+        self.timezone_selector_func = None
+
         if app is not None:
             self.init_app(app)
 
@@ -103,9 +106,6 @@ class Babel(object):
         #:      is anything but `None` this is used as new format string.
         #:      otherwise the default for that language is used.
         self.date_formats = self._date_formats
-
-        self.locale_selector_func = None
-        self.timezone_selector_func = None
 
         if self._configure_jinja:
             app.jinja_env.filters.update(


### PR DESCRIPTION
`self.locale_selector_func` and `timezone_selector_func` are set to `None` in `init_app()`. This breaks the following code structure:

``` python
app = Flask(instance)
babel = Babel()

@babel.timezoneselector
def get_timezone():
    pass

def init():
    app.config.from_pyfile('settings.py')
    babel.init_app(app)

if __name__ == '__main__':
    init()
    app.run(debug=True)
```

This patch moves the two values to `Babel.__init__()`.
