### PR TITLE
Update __init__.py

### DIFF
--- a/flask_babelex/__init__.py
+++ b/flask_babelex/__init__.py
@@ -531,7 +531,10 @@ class Domain(object):
             gettext(u'Hello %(name)s!', name='World')
         """
         t = self.get_translations()
-        return t.ugettext(string) % variables
+        if len(variables):
+            return t.ugettext(string) % variables
+        else:
+            return t.ugettext(string)
 
     def ngettext(self, singular, plural, num, **variables):
         """Translates a string with the current locale and passes in the
@@ -547,7 +550,10 @@ class Domain(object):
         """
         variables.setdefault('num', num)
         t = self.get_translations()
-        return t.ungettext(singular, plural, num) % variables
+        if len(variables):
+            return t.ungettext(singular, plural, num) % variables
+        else:
+            return t.ungettext(singular, plural, num)
 
     def pgettext(self, context, string, **variables):
         """Like :func:`gettext` but with a context.
@@ -555,7 +561,10 @@ class Domain(object):
         .. versionadded:: 0.7
         """
         t = self.get_translations()
-        return t.upgettext(context, string) % variables
+        if len(variables):
+            return t.upgettext(context, string) % variables
+        else:
+            return t.upgettext(context, string)
 
     def npgettext(self, context, singular, plural, num, **variables):
         """Like :func:`ngettext` but with a context.
@@ -564,7 +573,10 @@ class Domain(object):
         """
         variables.setdefault('num', num)
         t = self.get_translations()
-        return t.unpgettext(context, singular, plural, num) % variables
+        if len(variables):
+            return t.unpgettext(context, singular, plural, num) % variables
+        else:
+            return t.unpgettext(context, singular, plural, num)
 
     def lazy_gettext(self, string, **variables):
         """Like :func:`gettext` but the string returned is lazy which means


### PR DESCRIPTION
I've inserted return conditions in "gettext" family functions by reason of cause exceptions in flask-wtf extensions library. For example, Flask-WTF passing arguments to string after translation (in Length validator):

message = field.gettext('Field must be between %(min)d and %(max)d characters long.')
raise ValidationError(message % dict(min=self.min, max=self.max, length=l))

This cause KeyError exception, because "some string with %(arg)d" % {} is invoked. We need translated string primarily.
