### PR TITLE
Fix lazy gettext problem with domain evaluation

### DIFF
--- a/flask_babelex/__init__.py
+++ b/flask_babelex/__init__.py
@@ -629,6 +629,8 @@ def pgettext(*args, **kwargs):
 def npgettext(*args, **kwargs):
     return get_domain().npgettext(*args, **kwargs)
 def lazy_gettext(*args, **kwargs):
-    return get_domain().lazy_gettext(*args, **kwargs)
+    from speaklater import make_lazy_string
+    return make_lazy_string(gettext, *args, **kwargs)
 def lazy_pgettext(*args, **kwargs):
-    return get_domain().lazy_pgettext(*args, **kwargs)
+    from speaklater import make_lazy_string
+    return make_lazy_string(pgettext, *args, **kwargs)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -168,6 +168,17 @@ class GettextTestCase(unittest.TestCase):
         with app.test_request_context():
             assert text_type(yes) == 'Yes'
 
+    def test_lazy_gettext_defaultdomain(self):
+        app = flask.Flask(__name__)
+        domain = babel.Domain(domain='test')
+        b = babel.Babel(app, default_locale='de_DE', default_domain=domain)
+        first = lazy_gettext('first')
+        with app.test_request_context():
+            assert text_type(first) == 'erste'
+        app.config['BABEL_DEFAULT_LOCALE'] = 'en_US'
+        with app.test_request_context():
+            assert text_type(first) == 'first'
+
     def test_list_translations(self):
         app = flask.Flask(__name__)
         b = babel.Babel(app, default_locale='de_DE')


### PR DESCRIPTION
* Fixes a problem with lazy_gettext and lazy_pgettext evaluating the
  domain immediately instead of lazily evaluating the domain, causing
  e.g problem when you set a default domain.

See test case for example of where old implementation fails.